### PR TITLE
allow space in ENV value

### DIFF
--- a/run-with-heroku-env.js
+++ b/run-with-heroku-env.js
@@ -15,7 +15,7 @@ function getHerokuEnvs ({envs, herokuOptions} = {}) {
 
   const herokuEnvs = {}
   for (let line of execSync(cmd).toString().split(/\n/)) {
-    const [, key, value] = line.match(/^([A-Z\d_]+):\s+([^\s]+)$/) || []
+    const [, key, value] = line.match(/^([A-Z\d_]+):\s+(.+)$/) || []
     if (key && value && envs.includes(key)) {
       herokuEnvs[key] = value
     }


### PR DESCRIPTION
値に空白文字が含まれる場合に、空白文字から後が切り捨てられていた