### PR TITLE
heroku CLI v11で付く様になったカラーコードをFORCE_COLOR=0で抑制する

### DIFF
--- a/run-with-heroku-env.js
+++ b/run-with-heroku-env.js
@@ -9,7 +9,7 @@ function getHerokuEnvs({ envs, herokuOptions } = {}) {
     .map(key => `--${key} ${herokuOptions[key]}`)
     .join(' ');
 
-  const cmd = `heroku config ${option}`;
+  const cmd = `FORCE_COLOR=0 heroku config ${option}`;
   console.error(`== getting ENV ${envs}: ${cmd}`);
 
   const herokuEnvs = {};


### PR DESCRIPTION
## 問題

heroku CLI v11はカラーコードが付くので、configをparseできない


## 解決

herokuコマンドを呼び出す時に `FORCE_COLOR=0`を付けてカラーコードを無くす
この方法はheroku CLI v10に対しても互換性があるはずだ