### PR TITLE
heroku config --jsonとexecFileSyncに移行してカラーコード問題を根本解消

### DIFF
--- a/run-with-heroku-env.js
+++ b/run-with-heroku-env.js
@@ -1,22 +1,27 @@
 #!/usr/bin/env node
 
 const pkg = require('./package.json');
-const { execSync, spawn } = require('child_process');
+const { execFileSync, spawn } = require('child_process');
 const parseArgv = require('./parse-argv');
 
 function getHerokuEnvs({ envs, herokuOptions } = {}) {
-  const option = Object.keys(herokuOptions)
-    .map(key => `--${key} ${herokuOptions[key]}`)
-    .join(' ');
+  const args = ['config', '--json'];
+  for (const key of Object.keys(herokuOptions)) {
+    args.push(`--${key}`);
+    if (herokuOptions[key] !== true) {
+      args.push(String(herokuOptions[key]));
+    }
+  }
 
-  const cmd = `FORCE_COLOR=0 heroku config ${option}`;
-  console.error(`== getting ENV ${envs}: ${cmd}`);
+  console.error(`== getting ENV ${envs}: heroku ${args.join(' ')}`);
+
+  const result = execFileSync('heroku', args);
+  const config = JSON.parse(result.toString());
 
   const herokuEnvs = {};
-  for (let line of execSync(cmd).toString().split(/\n/)) {
-    const [, key, value] = line.match(/^([A-Z\d_]+):\s+(.+)$/) || [];
-    if (key && value && envs.includes(key)) {
-      herokuEnvs[key] = value;
+  for (const key of envs) {
+    if (config[key] !== undefined) {
+      herokuEnvs[key] = config[key];
     }
   }
   return herokuEnvs;

--- a/run-with-heroku-env.js
+++ b/run-with-heroku-env.js
@@ -16,7 +16,14 @@ function getHerokuEnvs({ envs, herokuOptions } = {}) {
   console.error(`== getting ENV ${envs}: heroku ${args.join(' ')}`);
 
   const result = execFileSync('heroku', args);
-  const config = JSON.parse(result.toString());
+  const output = result.toString();
+  let config;
+  try {
+    config = JSON.parse(output);
+  } catch (e) {
+    console.error(output);
+    process.exit(1);
+  }
 
   const herokuEnvs = {};
   for (const key of envs) {


### PR DESCRIPTION

## これまで

heroku CLI v11で、configコマンドの出力にANSIカラーコードが付くようになった
これが邪魔なので、 #4 でherokuコマンドの頭に `FORCE_COLOR=0` を付ける事で、色無しの出力をさせるようにした

### 問題

- コマンドの頭に環境変数を付ける書き方はWindowsで動作しない
- コマンドインジェクションが可能だった
- そもそもheroku CLIにはJSON出力オプションがあるので、それを使うべきだった

https://github.com/shokai/run-with-heroku-env/pull/4#issuecomment-4214050637 でも解説されている

## 修正

- `--json` オプションを使うようにした
  - heroku側のサーバーエラーなどでJSON以外が返ってくる場合もあるので、JSON.parse失敗したらエラーをそのまま出力してexit 1するようにした
- コマンドインジェクション対策のため、herokuコマンドの呼び出しを変更
  - execSyncからexecFileSyncに置き換えた
  - オプションの渡し方を文字列結合から配列渡しに置き換えた
